### PR TITLE
Fix duplicate visible footnote heading (GFM + manual ## Footnotes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Configured in `astro.config.mjs`:
 - **`remark-math`** — Parses `$...$` / `$$...$$` (and similar) for math.
 - **`rehype-katex`** — Renders math with KaTeX. Post layout loads KaTeX CSS from jsDelivr.
 - **Custom `remark-ignore-todo`** (`src/remark-ignore-todo.ts`) — Strips GFM task-list items (`- [ ]` / `- [x]`) from the AST so checklists do not appear in the HTML output.
+- **Custom `rehype-footnote-label-a11y`** (`src/rehype-footnote-label-a11y.ts`) — GFM always injects a footnote section title in HTML; this replaces it with a screen-reader-only `span#footnote-label` so you can add your own visible `## Footnotes` (or any heading) in the `.md` per post without a duplicate title.
 
 ## Integrations
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,13 +3,14 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import sitemap from "@astrojs/sitemap";
 import remarkIgnoreTODO from './src/remark-ignore-todo';
+import rehypeFootnoteLabelA11y from './src/rehype-footnote-label-a11y';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://patterns-in-leaves.com',
   markdown: {
     remarkPlugins: [remarkMath, remarkIgnoreTODO],
-    rehypePlugins: [rehypeKatex],
+    rehypePlugins: [rehypeKatex, rehypeFootnoteLabelA11y],
     // Cleaner footnote URLs (#fn-1) than default GitHub-style (#user-content-fn-1)
     // https://github.com/remarkjs/remark-rehype#options
     remarkRehype: {

--- a/src/rehype-footnote-label-a11y.ts
+++ b/src/rehype-footnote-label-a11y.ts
@@ -1,0 +1,41 @@
+import type { Element, Root } from "hast";
+import { visit } from "unist-util-visit";
+
+/**
+ * GFM injects `<h2 id="footnote-label">` inside `section.footnotes`, which
+ * duplicates a manual `## Footnotes` in the Markdown. Replace that heading with
+ * a visually hidden `<span id="footnote-label">` so `aria-describedby` on
+ * footnote refs still resolves.
+ */
+export default function rehypeFootnoteLabelA11y() {
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "section") return;
+      const cls = node.properties?.className;
+      const isFootnotes =
+        Array.isArray(cls) && cls.includes("footnotes");
+      if (!isFootnotes) return;
+
+      const first = node.children[0];
+      if (
+        !first ||
+        first.type !== "element" ||
+        first.tagName !== "h2" ||
+        first.properties?.id !== "footnote-label"
+      ) {
+        return;
+      }
+
+      const span: Element = {
+        type: "element",
+        tagName: "span",
+        properties: {
+          id: "footnote-label",
+          className: ["sr-only"],
+        },
+        children: [{ type: "text", value: "Footnotes" }],
+      };
+      node.children[0] = span;
+    });
+  };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,19 @@ html {
 	scrollbar-gutter: stable;
 }
 
+/* Visually hidden (screen readers only) — e.g. GFM can emit .sr-only headings */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
 body {
 	font-family: "heebo", sans-serif;
 	margin: auto;


### PR DESCRIPTION
## Problem

GitHub-Flavored Markdown footnotes inject `<h2 id="footnote-label">` inside `<section class="footnotes">`. If a post also uses a manual `## Footnotes` in the `.md`, readers saw **Footnotes** twice (and without `.sr-only` in our CSS, the injected title was not visually hidden).

## Approach

- **`src/rehype-footnote-label-a11y.ts`** — After `rehype-katex`, replace the injected `h2#footnote-label` with `<span id="footnote-label" class="sr-only">Footnotes</span>` so `aria-describedby` on footnote reference links still resolves.
- **`.sr-only`** in `global.css` for that span.
- **README** — Documents the plugin under the Markdown pipeline.

Authors keep **per-post control**: add your own visible heading (e.g. `## Footnotes`) only when the post uses footnotes; omit it when not needed.

## Verify

`npm run build`