### PR TITLE
feat: About page, site nav, light-mode code block background

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,0 +1,16 @@
+---
+const pathname = Astro.url.pathname.replace(/\/$/, "") || "/";
+const onHome = pathname === "/";
+const onAbout = pathname === "/about";
+---
+
+<header class="site-header">
+  <a href="/">
+    <h1>Patterns in Leaves</h1>
+  </a>
+  <nav class="site-nav" aria-label="Site">
+    <a href="/" aria-current={onHome ? "page" : undefined}>Posts</a>
+    <span class="site-nav-sep" aria-hidden="true">·</span>
+    <a href="/about" aria-current={onAbout ? "page" : undefined}>About</a>
+  </nav>
+</header>

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,0 +1,51 @@
+---
+/** Classic icon + label row for profile links. Icons use currentColor. */
+interface Props {
+  githubUrl?: string;
+  linkedInUrl?: string;
+}
+
+const {
+  githubUrl = "https://github.com/keithSchumacher",
+  linkedInUrl = "https://www.linkedin.com/in/keith-schumacher-02560a92/",
+} = Astro.props;
+---
+
+<ul class="social-links" role="list">
+  <li>
+    <a href={githubUrl} rel="me noreferrer noopener" target="_blank">
+      <svg
+        class="social-icon"
+        viewBox="0 0 98 96"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.225-22.23-5.38-22.23-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+        ></path>
+      </svg>
+      GitHub
+    </a>
+  </li>
+  <li>
+    <a href={linkedInUrl} rel="me noreferrer noopener" target="_blank">
+      <svg
+        class="social-icon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+        ></path>
+      </svg>
+      LinkedIn
+    </a>
+  </li>
+</ul>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,33 @@
+---
+import "../styles/global.css";
+import SiteHeader from "../components/SiteHeader.astro";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const {
+  title,
+  description = "Thoughts, notes, and writing by Keith Schumacher.",
+} = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="stylesheet" href="https://use.typekit.net/kgy5xxh.css" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="description" content={description} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <SiteHeader />
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,5 +1,12 @@
 ---
 import "../styles/global.css";
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const { title = "Patterns in Leaves", description } = Astro.props;
 ---
 
 <html lang="en">
@@ -11,6 +18,7 @@ import "../styles/global.css";
     <link rel="stylesheet" href="https://use.typekit.net/kgy5xxh.css" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
+    {description ? <meta name="description" content={description} /> : null}
     <!-- Katex -->
     <link
       rel="stylesheet"
@@ -18,8 +26,7 @@ import "../styles/global.css";
       integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV"
       crossorigin="anonymous"
     />
-    <!-- Pass props into layout so title can be blog post title -->
-    <title>Patterns in Leaves</title>
+    <title>{title}</title>
   </head>
 
   <body>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import MarkdownPostLayout from "../layouts/MarkdownPostLayout.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 import { getCollection, render } from "astro:content";
 import "../styles/global.css";
 
@@ -15,10 +16,11 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 ---
 
-<MarkdownPostLayout>
-  <a href="/">
-    <h1>Patterns in Leaves</h1>
-  </a>
+<MarkdownPostLayout
+  title={`${entry.data.title} — Patterns in Leaves`}
+  description={entry.data.description}
+>
+  <SiteHeader />
   <h1>{entry.data.title}</h1>
   <Content />
 </MarkdownPostLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import SocialLinks from "../components/SocialLinks.astro";
+
+const title = "About — Patterns in Leaves";
+const description =
+  "About Keith Schumacher: software, writing, and how to connect.";
+---
+
+<BaseLayout {title} {description}>
+  <article class="about-prose">
+    <h1>About</h1>
+    <p>
+      Hi, I’m <strong>Keith Schumacher</strong>. I share notes, essays, and
+      projects here under the name
+      <em>Patterns in Leaves</em>
+    </p>
+    <h2>Connect</h2>
+    <SocialLinks />
+  </article>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,36 +1,24 @@
 ---
-import "../styles/global.css";
+import BaseLayout from "../layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
 
 const allPosts = (await getCollection("post")).sort(
-  (a, b) => b.data.created.valueOf() - a.data.created.valueOf()
+  (a, b) => b.data.created.valueOf() - a.data.created.valueOf(),
 );
+
+const title = "Patterns in Leaves";
+const description = "Notes, essays, and projects by Keith Schumacher.";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
-    <!-- Adobe Fonts -->
-    <link rel="stylesheet" href="https://use.typekit.net/kgy5xxh.css" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="generator" content={Astro.generator} />
-    <title>Patterns in Leaves</title>
-  </head>
-  <body>
-    <a href="/">
-      <h1>Patterns in Leaves</h1>
-    </a>
-    <ul>
-      {
-        allPosts.map((post) => (
-          <li>
-            <a href={`/${post.id}`}>{post.data.title}</a>
-            <p>{post.data.description}</p>
-          </li>
-        ))
-      }
-    </ul>
-  </body>
-</html>
+<BaseLayout {title} {description}>
+  <ul>
+    {
+      allPosts.map((post) => (
+        <li>
+          <a href={`/${post.id}`}>{post.data.title}</a>
+          <p>{post.data.description}</p>
+        </li>
+      ))
+    }
+  </ul>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,74 @@ body {
 	font-size: 14pt;
 }
 
+/* Site chrome */
+.site-header {
+	margin-bottom: 1.5rem;
+}
+
+.site-header > a {
+	text-decoration: none;
+	color: inherit;
+}
+
+.site-header > a:hover h1 {
+	text-decoration: underline;
+}
+
+.site-nav {
+	margin-top: 0.35rem;
+	font-size: 0.95rem;
+}
+
+.site-nav a {
+	text-decoration: none;
+}
+
+.site-nav a:hover {
+	text-decoration: underline;
+}
+
+.site-nav a[aria-current="page"] {
+	font-weight: 600;
+}
+
+.site-nav-sep {
+	margin: 0 0.4rem;
+	opacity: 0.5;
+	user-select: none;
+}
+
+.social-links {
+	list-style: none;
+	padding: 0;
+	margin: 0.5rem 0 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem 1.25rem;
+	align-items: center;
+}
+
+.social-links a {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	text-decoration: none;
+}
+
+.social-links a:hover {
+	text-decoration: underline;
+}
+
+.social-icon {
+	width: 1.15em;
+	height: 1.15em;
+	flex-shrink: 0;
+}
+
+.about-prose h2 {
+	margin-top: 1.75rem;
+}
+
 @media only screen and (min-width: 750px) {
 	body {
 		max-width: 750px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,6 +125,14 @@ h1 {
 		border-radius: 4px;
 		font-size: 0.92em;
 	}
+
+	/*
+	 * Shiki emits inline background-color:#fff on pre.astro-code (github-light),
+	 * which vanishes on our white body — match inline code chip gray instead.
+	 */
+	pre.astro-code {
+		background-color: rgba(0, 0, 0, 0.06) !important;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary

- Add `/about` with short bio and GitHub + LinkedIn links (`SocialLinks.astro` with SVG icons)
- Shared `SiteHeader` (Posts · About) on index, about, and post pages; `BaseLayout` for non-post pages
- Post layout: per-post `<title>` and meta description
- **CSS:** light-mode Shiki `pre.astro-code` uses the same gray as inline code (overrides Shiki’s inline `#fff` on a white body)

## Verify

- [ ] `/about` and nav on home + posts
- [ ] Social URLs: [GitHub](https://github.com/keithSchumacher), [LinkedIn](https://www.linkedin.com/in/keith-schumacher-02560a92/)
- [ ] Light mode: fenced code blocks visible on long posts